### PR TITLE
 Remove deprecated use of `textScaleFactor`

### DIFF
--- a/lib/widgets/text.dart
+++ b/lib/widgets/text.dart
@@ -16,6 +16,7 @@ extension TextConverter on Text {
         textDirection: textDirection?.toPdfTextDirection(),
         softWrap: softWrap,
         overflow: overflow?.toPdfTextOverflow(),
+        // ignore: deprecated_member_use
         textScaleFactor: textScaleFactor ?? 1.0,
         style: style?.toPdfTextStyle(),
       );

--- a/test/widget_basic_test.dart
+++ b/test/widget_basic_test.dart
@@ -194,7 +194,7 @@ void main() {
         child: Stack(
           alignment: Alignment.center,
           children: [
-            const Text('Background', textScaleFactor: 5),
+            const Text('Background', textScaler: TextScaler.linear(5)),
             Opacity(
               opacity: 0.5,
               child: Container(
@@ -222,22 +222,22 @@ void main() {
             Positioned(
               top: 10,
               left: 10,
-              child: Text('Top Left', textScaleFactor: 3),
+              child: Text('Top Left', textScaler: TextScaler.linear(3)),
             ),
             Positioned(
               top: 10,
               right: 10,
-              child: Text('Top Right', textScaleFactor: 3),
+              child: Text('Top Right', textScaler: TextScaler.linear(3)),
             ),
             Positioned(
               bottom: 10,
               left: 10,
-              child: Text('Bottom Left', textScaleFactor: 3),
+              child: Text('Bottom Left', textScaler: TextScaler.linear(3)),
             ),
             Positioned(
               bottom: 10,
               right: 10,
-              child: Text('Bottom Right', textScaleFactor: 3),
+              child: Text('Bottom Right', textScaler: TextScaler.linear(3)),
             ),
           ],
         ),

--- a/test/widget_container_test.dart
+++ b/test/widget_container_test.dart
@@ -96,7 +96,7 @@ void main() {
               '$fit\n$shape',
               textDirection: TextDirection.ltr,
               textAlign: TextAlign.center,
-              textScaleFactor: 0.6,
+              textScaler: const TextScaler.linear(0.6),
             ),
           ),
         ));


### PR DESCRIPTION
Replaced `textScaleFactor` with `textScaler` in tests. 

In `text.dart` using it was unavoidable and therefore marked with an ignore comment.

Closes #50 