### PR TITLE
Support start and end  text alignments

### DIFF
--- a/lib/args/text_align.dart
+++ b/lib/args/text_align.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart' show TextAlign, debugPrint;
+import 'package:flutter/widgets.dart' show TextAlign;
 
 import 'package:pdf/widgets.dart' as pw show TextAlign;
 
@@ -13,12 +13,10 @@ extension TextAlignConverter on TextAlign {
         return pw.TextAlign.left;
       case TextAlign.right:
         return pw.TextAlign.right;
-      // not supported in pdf package:
-      // - TextAlign.end
-      // - TextAlign.start
-      default:
-        debugPrint('Unsupported TextAlign: $this; defaulting to null');
-        return null;
+      case TextAlign.start:
+        return pw.TextAlign.start;
+      case TextAlign.end:
+        return pw.TextAlign.end;
     }
   }
 }

--- a/test/widget_text_test.dart
+++ b/test/widget_text_test.dart
@@ -76,7 +76,7 @@ void main() async {
   testWidgets('Text Widgets Alignment', (tester) async {
     final children = <Widget>[];
     for (final align
-        in TextAlign.values.where((element) => element != TextAlign.end)) {
+        in TextAlign.values) {
       children.add(
         SizedBox(
           width: 120,


### PR DESCRIPTION
Add support for `TextAlign.start` and `TextAlign.end`.

Closes #63.