### PR TITLE
Fix: Unsupported `AppleSystemUIFont` font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- fix unsupported font error for AppleSystemUI font
+
 ## 0.2.2
 
 - fix widget args cast type error

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,7 +129,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.2.2"
   google_fonts:
     dependency: transitive
     description:

--- a/lib/args/text_style.dart
+++ b/lib/args/text_style.dart
@@ -22,7 +22,11 @@ import '../options/font_data.dart';
 import 'color.dart';
 
 extension TextStyleConverter on TextStyle {
-  Future<pw.TextStyle> toPdfTextStyle(FontData fontData) async => pw.TextStyle(
+  Future<pw.TextStyle> toPdfTextStyle(FontData fontData) async {
+    pw.Font? font = fontFamily != null 
+      ? await resolveFont(fontFamily!, fontData)
+      : null;
+    return pw.TextStyle(
         color: color?.toPdfColor(),
         fontSize: fontSize,
         fontStyle: fontStyle?.toPdfFontStyle(),
@@ -34,13 +38,12 @@ extension TextStyleConverter on TextStyle {
         decorationColor: decorationColor?.toPdfColor(),
         decorationStyle: decorationStyle?.toPdfTextDecorationStyle(),
         decorationThickness: decorationThickness,
-        inherit: inherit,
-        font: fontFamily != null
-            ? await resolveFont(fontFamily!, fontData)
-            : null,
+        inherit: !inherit && font == null ? true : inherit,
+        font: font,
         fontFallback: fontFamilyFallback != null
-            ? await Future.wait(fontFamilyFallback!
-                .map((String font) => resolveFont(font, fontData)))
+            ? (await Future.wait(fontFamilyFallback!
+                .map((String font) => resolveFont(font, fontData))))
+                .whereType<pw.Font>().toList()
             : [],
         background: backgroundColor != null
             ? pw.BoxDecoration(
@@ -48,9 +51,12 @@ extension TextStyleConverter on TextStyle {
               )
             : null,
       );
+  }
 
-  Future<pw.Font> resolveFont(String font, FontData fontData) async {
+  Future<pw.Font?> resolveFont(String font, FontData fontData) async {
     switch (font) {
+      case '.AppleSystemUIFont':
+        null;
       case 'Courier':
         return pw.Font.courier();
       case 'Helvetica':


### PR DESCRIPTION
When exporting a `Text` widget that uses a `TextStyle` provided through  a `TextTheme` (on macOS & iOS) the following error is thrown: 
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Exception: Unsupported Font: .AppleSystemUIFont
#0      TextStyleConverter.resolveFont (package:flutter_to_pdf/args/text_style.dart:66:11)
#1      TextStyleConverter.toPdfTextStyle (package:flutter_to_pdf/args/text_style.dart:39:21)
#2      TextConverter.toPdfWidget (package:flutter_to_pdf/widgets/text.dart:22:29)
#3      ExportInstance.matchWidget (package:flutter_to_pdf/export_instance.dart:176:40)
#4      ExportInstance._visit (package:flutter_to_pdf/export_instance.dart:58:29)
```

Closes #78.