### PR TITLE
Fix incorrect context used when creating pw.Widget

### DIFF
--- a/lib/export_delegate.dart
+++ b/lib/export_delegate.dart
@@ -18,17 +18,17 @@ class ExportDelegate {
     Map<String, String> ttfFonts = const {},
   }) : fontData = FontData(ttfFonts);
 
-  final Map<String, ExportFrame> _registeredFrames = {};
+  final Map<String, ExportFrameContext> _registeredFrames = {};
 
   /// Registers a new [ExportFrame] to the [ExportDelegate].
-  void registerFrame(ExportFrame frame) {
+  void registerFrame(ExportFrameContext frame) {
     _registeredFrames[frame.frameId] = frame;
   }
 
   /// Returns the [ExportFrame] with the given [frameId].
   /// Throws an [Exception] if no [ExportFrame] is found.
-  ExportFrame getFrame(String frameId) {
-    final ExportFrame? frame = _registeredFrames[frameId];
+  ExportFrameContext getFrame(String frameId) {
+    final ExportFrameContext? frame = _registeredFrames[frameId];
 
     if (frame == null) {
       throw Exception('No frame with id $frameId found');
@@ -46,16 +46,12 @@ class ExportDelegate {
   /// Exports the [ExportFrame] with the given [frameId] to a [pw.Document].
   Future<pw.Document> exportToPdfDocument(String frameId,
       {ExportOptions? overrideOptions}) async {
-    final ExportFrame? frame = _registeredFrames[frameId];
-
-    if (frame == null) {
-      throw Exception('No frame with id $frameId found');
-    }
+    final frame = getFrame(frameId);
 
     if (overrideOptions != null) {
       ExportDelegate delegate = copyWith(options: overrideOptions);
       return await delegate._exportDocument(
-          frame.exportWidget, frame.exportContext!);
+          frame.exportWidget, frame.exportContext);
     }
 
     return await _exportDocument(frame.exportWidget, frame.exportContext!);
@@ -64,29 +60,29 @@ class ExportDelegate {
   /// Exports the [ExportFrame] with the given [frameId] to a [pw.Page].
   Future<pw.Page> exportToPdfPage(String frameId,
       {ExportOptions? overrideOptions}) async {
-    final ExportFrame frame = getFrame(frameId);
+    final frame = getFrame(frameId);
 
     if (overrideOptions != null) {
       ExportDelegate delegate = copyWith(options: overrideOptions);
       return await delegate._exportPage(
-          frame.exportWidget, frame.exportContext!);
+          frame.exportWidget, frame.exportContext);
     }
 
-    return await _exportPage(frame.exportWidget, frame.exportContext!);
+    return await _exportPage(frame.exportWidget, frame.exportContext);
   }
 
   /// Exports the [ExportFrame] with the given [frameId] to a [pw.Widget].
   Future<pw.Widget> exportToPdfWidget(String frameId,
       {ExportOptions? overrideOptions}) async {
-    final ExportFrame frame = getFrame(frameId);
+    final frame = getFrame(frameId);
 
     if (overrideOptions != null) {
       ExportDelegate delegate = copyWith(options: overrideOptions);
       return await delegate._exportWidget(
-          frame.exportWidget, frame.exportContext!);
+          frame.exportWidget, frame.exportContext);
     }
 
-    return await _exportWidget(frame.exportWidget, frame.exportContext!);
+    return await _exportWidget(frame.exportWidget, frame.exportContext);
   }
 
   /// Exports the given [widget] to a [pw.Widget].

--- a/lib/export_delegate.dart
+++ b/lib/export_delegate.dart
@@ -20,13 +20,13 @@ class ExportDelegate {
 
   final Map<String, ExportFrameContext> _registeredFrames = {};
 
-  /// Registers a new [ExportFrame] to the [ExportDelegate].
-  void registerFrame(ExportFrameContext frame) {
-    _registeredFrames[frame.frameId] = frame;
+  /// Registers a new [ExportFrame] with the given [ExportFrameContext] to the [ExportDelegate].
+  void registerFrame(ExportFrameContext frameContext) {
+    _registeredFrames[frameContext.frameId] = frameContext;
   }
 
-  /// Returns the [ExportFrame] with the given [frameId].
-  /// Throws an [Exception] if no [ExportFrame] is found.
+  /// Returns the [ExportFrameContext] with the given [frameId].
+  /// Throws an [Exception] if no [ExportFrameContext] is found.
   ExportFrameContext getFrame(String frameId) {
     final ExportFrameContext? frame = _registeredFrames[frameId];
 

--- a/lib/export_frame.dart
+++ b/lib/export_frame.dart
@@ -15,16 +15,25 @@ class ExportFrame extends StatelessWidget {
     super.key,
   });
 
-  static BuildContext? _exportContext;
-
-  BuildContext? get exportContext => _exportContext;
-
-  Widget get exportWidget => child;
-
   @override
   Widget build(BuildContext context) {
-    _exportContext = context;
-    exportDelegate.registerFrame(this);
+    exportDelegate.registerFrame(ExportFrameContext(
+        frameId: frameId,
+        exportWidget: child,
+        exportContext: context
+    ));
     return child;
   }
+}
+
+class ExportFrameContext {
+  final String frameId;
+  final Widget exportWidget;
+  final BuildContext exportContext;
+
+  ExportFrameContext({
+    required this.frameId,
+    required this.exportWidget,
+    required this.exportContext
+  });
 }


### PR DESCRIPTION
ExportFrame was using a single static context assigned at widget build time. If the widget tree has multiple export frames in it then only the last widget frame's context is used. This change moves the context into a new object that is registered with the ExportDelegate instead of the ExportFrame widget. This object holds the frameId, widget, and the current Build context. When a ExportFrame is used to create a document the correct context will be used. There is also the added benefit that the static BuildContext will no longer be leaked as the reference to the context will be removed with the ExportDelegate.

When the wrong context is used you get a `contextElement is null` assertion exception when using CaptureWrapper.  I have tested this with exporting using exportPdfPage and exportPdfDocument.  The change also plays nice with `exportUnbuiltWidget`, though you still cannot use `CaptureWrapper` with `exportUnbuiltWidget`, but that was an existing issue.
