### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- add support for `overflow` in `Stack` widget
+
 ## 0.3.0
 
 - add support for `Text.rich` widget

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```yaml
 dependencies:
-  flutter_to_pdf: ^0.3.0
+  flutter_to_pdf: ^0.4.0
 ```
 
 Alternatively, your editor might support `flutter pub get`. Check the docs for your editor to learn more.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_to_pdf
 description: A package to export any Flutter widget to a PDF-Document, PDF-Page or PDF-File. Further customization of the export process is possible through the export options.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/joseph-grabinger/flutter_to_pdf/tree/main
 repository: https://github.com/joseph-grabinger/flutter_to_pdf
 issue_tracker: https://github.com/joseph-grabinger/flutter_to_pdf/issues


### PR DESCRIPTION
Release v0.4.0 to [pub.dev](https://pub.dev/).

- adds support for `overflow` in `Stack` widget